### PR TITLE
setCurrent to create copy when passed Id

### DIFF
--- a/src/service-module/mutations.js
+++ b/src/service-module/mutations.js
@@ -126,8 +126,16 @@ export default function makeServiceMutations (service) {
       }
     },
 
-    setCurrent (state, item) {
-      let id = isObject(item) ? item[idField] : item
+    setCurrent (state, itemOrId) {
+      let id
+      let item
+      if (isObject(itemOrId)) {
+        id = itemOrId[idField]
+        item = itemOrId
+      } else {
+        id = itemOrId
+        item = state.keyedById[id]
+      }
       state.currentId = id
       state.copy = _cloneDeep(item)
     },

--- a/test/service-module/mutations.test.js
+++ b/test/service-module/mutations.test.js
@@ -247,6 +247,11 @@ describe('Service Module - Mutations', () => {
 
     assert(state.currentId === 2)
     assert.deepEqual(state.copy, item2)
+
+    setCurrent(state, item1._id)
+
+    assert(state.currentId === 1)
+    assert.deepEqual(state.copy, item1)
   })
 
   it('clearCurrent', () => {


### PR DESCRIPTION
### Summary
- [x] Tell us about the problem your pull request is solving.
- [x] Are there any open issues that are related to this?
- [x] Is this PR dependent on PRs in other repos?

See #48. 

When calling mutation `setCurrent(id)` it should copy the current item into copy per the README

I included a test that fails before the change made to `setCurrent`. Before if `setCurrent` was passed an Id the `copy` would be set to the Id instead of the object.
