### PR TITLE
Add nuxt auth storage section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,19 @@ export default function (context) {
 
 For a summary, the `initAuth` function will make auth available in the state without much configuration.
 
+### Authentication storage with nuxt
+
+Since nuxt is running both client- and server side, it has limits on the availability of certain browser specific variables like `window`. Because of that, trying to configure the feathers client to use `window.localStorage` will result in an error or unexpected / not working behaviour. There's a simple solution though:
+
+When you configure the auth module in your feathers-client, use [cookie-storage](https://www.npmjs.com/package/cookie-storage) instead of `window.localStorage` to store the authentication data inside a cookie.
+
+```
+import { CookieStorage } from 'cookie-storage';
+
+const feathersClient = feathers()
+  .configure(auth({ storage: new CookieStorage() }));
+```
+
 ### Configuration
 You can provide a `userService` in the auth plugin's options to automatically populate the user upon successful login.
 


### PR DESCRIPTION
I updated the readme mentioning the cookie-storage library, as I was running into the problem of using `window.localStorage` with nuxt myself. 

If there any improvements I can make on this PR, please feel free to tell me.