### PR TITLE
Use serialize-error for auth errors mutations

### DIFF
--- a/src/auth-module/mutations.js
+++ b/src/auth-module/mutations.js
@@ -1,3 +1,5 @@
+import serializeError from 'serialize-error'
+
 export default function makeAuthMutations (feathers) {
   return {
     setAccessToken (state, payload) {
@@ -24,13 +26,13 @@ export default function makeAuthMutations (feathers) {
     },
 
     setAuthenticateError (state, error) {
-      state.errorOnAuthenticate = Object.assign({}, error)
+      state.errorOnAuthenticate = Object.assign({}, serializeError(error))
     },
     clearAuthenticateError (state) {
       state.errorOnAuthenticate = null
     },
     setLogoutError (state, error) {
-      state.errorOnLogout = Object.assign({}, error)
+      state.errorOnLogout = Object.assign({}, serializeError(error))
     },
     clearLogoutError (state) {
       state.errorOnLogout = null


### PR DESCRIPTION
Hey!

This is kinda related to https://github.com/feathers-plus/feathers-vuex/pull/60. Errors for the `auth` module where not set correctly. I used the same logic from the service module mutations.