### PR TITLE
Add an 'upsert' option to service modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ const defaultOptions = {
   idField: 'id', // The field in each record that will contain the id
   autoRemove: false, // automatically remove records missing from responses (only use with feathers-rest)
   nameStyle: 'short', // Determines the source of the module name. 'short' or 'path'
-  enableEvents: true // Set to false to explicitly disable socket event handlers.
+  enableEvents: true, // Set to false to explicitly disable socket event handlers.
+  upsert: false // add new records pushed by 'updated/patched' socketio events into store, instead of discarding them
 }
 ```
 
@@ -117,6 +118,7 @@ Each service comes loaded with the following default state:
     idField: 'id',
     servicePath: 'v1/todos' // The full service path
     autoRemove: false, // Indicates that this service will not automatically remove results missing from subsequent requests.
+    upsert: false, // Indicates that this service will discard new records pushed by 'updated/patched' socketio events, instead of adding them to store.
     paginate: false, // Indicates if pagination is enabled on the Feathers service.
 
     isFindPending: false,

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ export default new Vuex.Store({
       nameStyle: 'path', // Use the full service path as the Vuex module name, instead of just the last section
       namespace: 'custom-namespace', // Customize the Vuex module name.  Overrides nameStyle.
       autoRemove: true, // automatically remove records missing from responses (only use with feathers-rest)
-      enableEvents: false // turn off socket event listeners. It's true by default
+      enableEvents: false, // turn off socket event listeners. It's true by default
+      upsert: true // add new records pushed by 'updated/patched' socketio events into store, instead of discarding them. It's false by default
     })
 
     // Add custom state, getters, mutations, or actions, if needed.  See example in another section, below.

--- a/src/service-module/actions.js
+++ b/src/service-module/actions.js
@@ -36,31 +36,50 @@ export default function makeServiceActions (service) {
     // Two query syntaxes are supported, since actions only receive one argument.
     //   1. Just pass the id: `get(1)`
     //   2. Pass arguments as an array: `get([null, params])`
-    get ({ commit, dispatch }, args) {
+    get ({ state, getters, commit, dispatch }, args) {
       let id
       let params
+      let skipRequestIfExists
 
       if (Array.isArray(args)) {
         id = args[0]
         params = args[1]
       } else {
         id = args
+        params = {}
       }
 
-      commit('setGetPending')
+      if ('skipRequestIfExists' in params) {
+        skipRequestIfExists = params.skipRequestIfExists
+        delete params.skipRequestIfExists
+      } else {
+        skipRequestIfExists = state.skipRequestIfExists
+      }
 
-      return service.get(id, params)
-        .then(item => {
-          dispatch('addOrUpdate', item)
-          commit('setCurrent', item)
-          commit('unsetGetPending')
-          return item
-        })
-        .catch(error => {
-          commit('setGetError', error)
-          commit('unsetGetPending')
-          return Promise.reject(error)
-        })
+      function getFromRemote () {
+        commit('setGetPending')
+        return service.get(id, params)
+          .then(item => {
+            dispatch('addOrUpdate', item)
+            commit('setCurrent', item)
+            commit('unsetGetPending')
+            return item
+          })
+          .catch(error => {
+            commit('setGetError', error)
+            commit('unsetGetPending')
+            return Promise.reject(error)
+          })
+      }
+
+      // If the records is already in store, return it
+      const existedItem = getters.get(id, params)
+      if (existedItem) {
+        commit('setCurrent', existedItem)
+        if (!skipRequestIfExists) getFromRemote()
+        return Promise.resolve(existedItem)
+      }
+      return getFromRemote()
     },
 
     create ({ commit, dispatch }, data) {

--- a/src/service-module/mutations.js
+++ b/src/service-module/mutations.js
@@ -20,9 +20,23 @@ export default function makeServiceMutations (servicePath) {
   }
 
   function updateItem (state, item) {
-    const { idField } = state
+    const { idField, upsert } = state
     let id = item[idField]
-    state.keyedById[id] = item
+
+    // Simply rewrite the record if the it's already in the `ids` list.
+    if (state.ids.includes(id)) {
+      state.keyedById[id] = item
+      return
+    }
+
+    // if upsert then add the record into the state, else discard it.
+    if (upsert) {
+      state.ids.push(id)
+      state.keyedById = {
+        ...state.keyedById,
+        [id]: item
+      }
+    }
   }
 
   return {

--- a/src/service-module/service-module.js
+++ b/src/service-module/service-module.js
@@ -10,6 +10,7 @@ const defaults = {
   nameStyle: 'short', // Determines the source of the module name. 'short', 'path', or 'explicit'
   enableEvents: true, // Listens to socket.io events when available
   upsert: false, // add new records pushed by 'updated/patched' socketio events into store, instead of discarding them
+  skipRequestIfExists: false,
   state: {},     // for custom state
   getters: {},   // for custom getters
   mutations: {}, // for custom mutations
@@ -29,7 +30,7 @@ export default function servicePluginInit (feathersClient, globalOptions = {}) {
     }
 
     options = Object.assign({}, globalOptions, options)
-    const { idField, autoRemove, nameStyle } = options
+    const { idField, autoRemove, nameStyle, upsert, skipRequestIfExists } = options
 
     if (typeof servicePath !== 'string') {
       throw new Error('The first argument to setup a feathers-vuex service must be a string')
@@ -41,7 +42,7 @@ export default function servicePluginInit (feathersClient, globalOptions = {}) {
     }
     const paginate = service.hasOwnProperty('paginate') && service.paginate.hasOwnProperty('default')
 
-    const defaultState = makeState(servicePath, { idField, autoRemove, paginate })
+    const defaultState = makeState(servicePath, { idField, autoRemove, paginate, upsert, skipRequestIfExists })
     const defaultGetters = makeGetters(servicePath)
     const defaultMutations = makeMutations(servicePath)
     const defaultActions = makeActions(service)

--- a/src/service-module/service-module.js
+++ b/src/service-module/service-module.js
@@ -9,6 +9,7 @@ const defaults = {
   autoRemove: false, // automatically remove records missing from responses (only use with feathers-rest)
   nameStyle: 'short', // Determines the source of the module name. 'short', 'path', or 'explicit'
   enableEvents: true, // Listens to socket.io events when available
+  upsert: false, // add new records pushed by 'updated/patched' socketio events into store, instead of discarding them
   state: {},     // for custom state
   getters: {},   // for custom getters
   mutations: {}, // for custom mutations

--- a/src/service-module/state.js
+++ b/src/service-module/state.js
@@ -1,4 +1,7 @@
-export default function makeDefaultState (servicePath, { idField, autoRemove, paginate }) {
+export default function makeDefaultState(
+  servicePath,
+  { idField, autoRemove, paginate, upsert, skipRequestIfExists }
+) {
   const state = {
     ids: [],
     keyedById: {},
@@ -8,6 +11,8 @@ export default function makeDefaultState (servicePath, { idField, autoRemove, pa
     servicePath,
     autoRemove,
     pagination: {},
+    upsert,
+    skipRequestIfExists,
 
     isFindPending: false,
     isGetPending: false,
@@ -22,6 +27,6 @@ export default function makeDefaultState (servicePath, { idField, autoRemove, pa
     errorOnUpdate: null,
     errorOnPatch: null,
     errorOnRemove: null
-  }
-  return state
+  };
+  return state;
 }

--- a/test/service-module/mutations.test.js
+++ b/test/service-module/mutations.test.js
@@ -103,22 +103,70 @@ describe('Service Module - Mutations', function () {
     assert(state.keyedById[2] === item2)
   })
 
-  it('updateItem', function () {
-    const state = this.state
-    const item1 = {
-      _id: 1,
-      test: true
-    }
-    const items = [item1]
-    addItems(state, items)
+  describe('updateItem', function () {
+    it('updates existing item with upsert=true', function () {
+      const state = this.state
+      state.upsert = true
+      const item1 = {
+        _id: 1,
+        test: true
+      }
+      const items = [item1]
+      addItems(state, items)
 
-    const item1updated = {
-      _id: 1,
-      test: false
-    }
-    updateItem(state, item1updated)
+      const item1updated = {
+        _id: 1,
+        test: false
+      }
+      updateItem(state, item1updated)
 
-    assert(state.keyedById[1].test === false)
+      assert(state.keyedById[1].test === false)
+    })
+
+    it('updates existing item with upsert=false', function () {
+      const state = this.state
+      state.upsert = false
+      const item1 = {
+        _id: 1,
+        test: true
+      }
+      const items = [item1]
+      addItems(state, items)
+
+      const item1updated = {
+        _id: 1,
+        test: false
+      }
+      updateItem(state, item1updated)
+
+      assert(state.keyedById[1].test === false)
+    })
+
+    it('adds non-existing item with upsert=true', function () {
+      const state = this.state
+      state.upsert = true
+
+      const item1updated = {
+        _id: 1,
+        test: false
+      }
+      updateItem(state, item1updated)
+
+      assert(state.keyedById[1].test === false)
+    })
+
+    it('discards non-existing item with upsert=false', function () {
+      const state = this.state
+      state.upsert = false
+
+      const item1updated = {
+        _id: 1,
+        test: false
+      }
+      updateItem(state, item1updated)
+
+      assert(state.keyedById[1] == null)
+    })
   })
 
   it('updateItems', function () {


### PR DESCRIPTION
As discussed in #110, this 'upsert' option allows users to choose whether they want to discard the new (currently not existing in the store) records pushed by 'updated/patched' socketio events or to add them into store.

Of coz we can discuss for a better name. The term 'upsert' is used in some database to indicate the similar behavior. 