### PR TITLE
Dates in instanceDefaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "feathers-vuex",
   "description": "FeathersJS, Vue, and Nuxt for the artisan developer",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "homepage": "https://github.com/feathersjs/feathers-vuex",
   "main": "lib/",
   "keywords": [

--- a/src/service-module/model.js
+++ b/src/service-module/model.js
@@ -25,6 +25,15 @@ export default function (options) {
           // Reset the instance default for this prop to null
           _instanceDefaults[key] = null
         }
+
+        // Or if the value is a Date
+        if (modelName === Date) {
+          // Store the relationships
+          relationships[key] = Date
+
+          // Reset the instance default for this prop to null
+          _instanceDefaults[key] = null
+        }
       })
 
       if (options.isClone) {
@@ -42,18 +51,26 @@ export default function (options) {
           // Handle arrays
           if (Array.isArray(related)) {
             related.forEach((item, index) => {
-              const { model, storedModel } = createRelatedInstance({ item, Model, idField, store })
+              if (Model === Date) {
+                related[index] = new Date(item)
+              } else {
+                const { model, storedModel } = createRelatedInstance({ item, Model, idField, store })
 
-              // Replace the original array value with a reference to the model
-              related[index] = storedModel || model
+                // Replace the original array index with a reference to the model
+                related[index] = storedModel || model
+              }
             })
 
           // Handle objects
           } else {
-            const { model, storedModel } = createRelatedInstance({ item: related, Model, idField, store })
+            if (Model === Date) {
+              data[prop] = new Date(data[prop])
+            } else {
+              const { model, storedModel } = createRelatedInstance({ item: related, Model, idField, store })
 
-            // Replace the data's prop value with a reference to the model
-            data[prop] = storedModel || model
+              // Replace the data's prop value with a reference to the model
+              data[prop] = storedModel || model
+            }
           }
         }
       })

--- a/test/service-module/service-module.test.js
+++ b/test/service-module/service-module.test.js
@@ -281,7 +281,7 @@ describe('Service Module', () => {
       this.Todo = globalModels.Todo
     })
 
-    it.only('converts keys that contain the Date constructor into date instances', function () {
+    it('converts keys that contain the Date constructor into date instances', function () {
       const { Todo } = this
       const createdAt = '2018-05-01T04:42:24.136Z'
       const todo = new Todo({

--- a/test/service-module/service-module.test.js
+++ b/test/service-module/service-module.test.js
@@ -263,6 +263,39 @@ describe('Service Module', () => {
     })
   })
 
+  describe('Models - Dates', function () {
+    beforeEach(function () {
+      this.store = new Vuex.Store({
+        strict: true,
+        plugins: [
+          service('todos', {
+            instanceDefaults: {
+              id: null,
+              description: '',
+              isComplete: false,
+              createdAt: Date
+            }
+          })
+        ]
+      })
+      this.Todo = globalModels.Todo
+    })
+
+    it.only('converts keys that contain the Date constructor into date instances', function () {
+      const { Todo } = this
+      const createdAt = '2018-05-01T04:42:24.136Z'
+      const todo = new Todo({
+        description: 'Go on a date.',
+        isComplete: true,
+        createdAt
+      })
+
+      assert(typeof todo.createdAt === 'object', 'todo.createdAt is an instance of object')
+      assert(todo.createdAt.constructor.name === 'Date', 'todo.createdAt is an instance of date')
+      assert(todo.createdAt.toString() === new Date(createdAt).toString(), 'the correct date was used')
+    })
+  })
+
   describe('Models - Relationships', function () {
     beforeEach(function () {
       this.store = new Vuex.Store({


### PR DESCRIPTION
You can now pass the Date class as the value of an instanceDefault to have that value automatically converted to a Date.

```js
new Vuex.Store({
  strict: true,
  plugins: [
    service('todos', {
      instanceDefaults: {
        id: null,
        description: '',
        isComplete: false,
        createdAt: Date
      }
    })
  ]
})

it('converts keys that contain the Date constructor into date instances', function () {
  const { Todo } = this
  const createdAt = '2018-05-01T04:42:24.136Z'
  const todo = new Todo({
    description: 'Go on a date.',
    isComplete: true,
    createdAt
  })

  assert(typeof todo.createdAt === 'object', 'todo.createdAt is an instance of object')
  assert(todo.createdAt.constructor.name === 'Date', 'todo.createdAt is an instance of date')
  assert(todo.createdAt.toString() === new Date(createdAt).toString(), 'the correct date was used')
})
```