### PR TITLE
Allow passing model name

### DIFF
--- a/src/service-module/model.js
+++ b/src/service-module/model.js
@@ -6,7 +6,7 @@ const defaults = {
 
 export default function (options) {
   options = Object.assign({}, defaults, options)
-  const { idField, preferUpdate, instanceDefaults, globalModels } = options
+  const { idField, preferUpdate, instanceDefaults, globalModels, modelName } = options
   // Don't modify the original instanceDefaults. Clone it with accessors intact
   let _instanceDefaults = cloneWithAccessors(instanceDefaults)
 
@@ -170,7 +170,8 @@ export default function (options) {
 
   Object.assign(FeathersVuexModel, {
     options,
-    copiesById: {} // For cloned data
+    copiesById: {}, // For cloned data
+    modelName
   })
 
   return FeathersVuexModel

--- a/src/service-module/service-module.js
+++ b/src/service-module/service-module.js
@@ -15,7 +15,7 @@ const defaults = {
   preferUpdate: false, // When true, calling model.save() will do an update instead of a patch.
   apiPrefix: '', // Setting to 'api1/' will prefix the store moduleName, unless `namespace` is used, then this is ignored.
   debug: false,  // Set to true to enable logging messages.
-  modelPath: '', // The location of this service's Model in the Vue plugin (globalModels object). Added in the servicePlugin method
+  modelName: '', // The location of this service's Model in the Vue plugin (globalModels object). Added in the servicePlugin method
   instanceDefaults: {}, // The default values for the instance when `const instance =new Model()`
   replaceItems: false, // Instad of merging in changes in the store, replace the entire record.
   keepCopiesInStore: false, // Set to true to store cloned copies in the store instead of on the Model.
@@ -104,7 +104,7 @@ export default function servicePluginInit (feathersClient, globalOptions = {}, g
       const modelInfo = registerModel(Model, globalModels, apiPrefix, servicePath)
 
       Object.defineProperty(Model, 'name', { value: modelInfo.name })
-      module.state.modelPath = modelInfo.path
+      module.state.modelName = modelInfo.path
       store.registerModule(namespace, module)
 
       // Upgrade the Model's API methods to use the store.actions

--- a/src/utils.js
+++ b/src/utils.js
@@ -117,9 +117,9 @@ export function registerModel (Model, globalModels, apiPrefix, servicePath) {
 // Creates a Model class name from the last part of the servicePath
 export function getModelName (Model) {
   // If the Model.name has been customized, use it.
-  // if (Model.name && Model.name !== 'FeathersVuexModel') {
-  //   return Model.name
-  // }
+  if (Model.modelName) {
+    return Model.modelName
+  }
 
   // Otherwise, use an inflection of the last bit of the servicePath
   const parts = Model.servicePath.split('/')

--- a/test/service-module/service-module.test.js
+++ b/test/service-module/service-module.test.js
@@ -263,7 +263,7 @@ describe('Service Module', () => {
     })
   })
 
-  describe('Models - Methods', function () {
+  describe('Models - modelName', function () {
     beforeEach(function () {
       this.store = new Vuex.Store({
         strict: true,

--- a/test/service-module/service-module.test.js
+++ b/test/service-module/service-module.test.js
@@ -169,7 +169,7 @@ describe('Service Module', () => {
         idField: 'id',
         instanceDefaults: taskDefaults,
         keepCopiesInStore: true,
-        modelPath: '',
+        modelName: '',
         mutations: {},
         nameStyle: 'short',
         preferUpdate: false,
@@ -260,6 +260,27 @@ describe('Service Module', () => {
 
       task.save({ test: true })
       assert(called, 'update should have been called')
+    })
+  })
+
+  describe('Models - Methods', function () {
+    beforeEach(function () {
+      this.store = new Vuex.Store({
+        strict: true,
+        plugins: [
+          service('media'),
+          service('hotspot-media', {
+            modelName: 'HotspotMedia'
+          })
+        ]
+      })
+      this.Medium = globalModels.Medium
+      this.HotspotMedia = globalModels.HotspotMedia
+    })
+
+    it('allows passing a custom Model name', function () {
+      assert(!this.HotspotMedium, `the model wasn't in the default location`)
+      assert(this.HotspotMedia, 'the model is named correctly.')
     })
   })
 
@@ -635,7 +656,7 @@ describe('Service Module', () => {
         isPatchPending: false,
         isRemovePending: false,
         keyedById: {},
-        modelPath: 'Todo',
+        modelName: 'Todo',
         addOnUpsert: false,
         skipRequestIfExists: false,
         preferUpdate: false,


### PR DESCRIPTION
You can now pass a `modelName` to rename the model inside the $FeathersVuex plugin.

```js
this.store = new Vuex.Store({
  strict: true,
  plugins: [
    service('media'),
    service('hotspot-media', {
      modelName: 'HotspotMedia'
    })
  ]
})

import Vue from 'vue'
import Vuex from 'vuex'
import feathersVuex from 'feathers-vuex'
import feathersClient from '../feathers-client'

const { service, auth, FeathersVuex } = feathersVuex(feathersClient, { idField: '_id' })
const { serviceModule, serviceModel, servicePlugin } = service

assert(Vue.$FeathersVuex.Medium) // --> media becomes Medium, by default (wtf? not what I wanted, but it's valid English ;)
assert(Vue.$FeathersVuex.HotspotMedia) // --> hotspot-media is manually set to "HotspotMedia"
```