### PR TITLE
Perform shallow commits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "feathers-vuex",
-  "version": "1.2.0-pre.23",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3445,6 +3445,11 @@
         "is-extglob": "1.0.0"
       }
     },
+    "fast-copy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-1.2.0.tgz",
+      "integrity": "sha512-c1v5Wxv/ykagSbGk1JdByfGP6dSPIUNmyiGL9Wc1Rk+H91o1HEFygmUZTG7CeRWaAqYOFTvZ3KFGHFi7daQCfw=="
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -6207,11 +6212,6 @@
       "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
       "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
       "dev": true
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.cond": {
       "version": "4.5.2",

--- a/package.json
+++ b/package.json
@@ -67,12 +67,12 @@
   },
   "dependencies": {
     "debug": "^3.1.0",
+    "fast-copy": "^1.2.0",
     "feathers-commons": "^0.8.7",
     "feathers-errors": "^2.9.2",
     "feathers-query-filters": "^2.1.2",
     "inflection": "^1.12.0",
     "jwt-decode": "^2.2.0",
-    "lodash.clonedeep": "^4.5.0",
     "lodash.isobject": "^3.0.2",
     "lodash.merge": "^4.6.0",
     "lodash.trim": "^4.5.1",

--- a/src/service-module/model.js
+++ b/src/service-module/model.js
@@ -118,7 +118,7 @@ export default function (options) {
     commit () {
       if (this.isClone) {
         const id = this[idField]
-        this._commit(id)
+        return this._commit(id)
       } else {
         throw new Error('You cannnot call commit on a non-copy')
       }

--- a/src/service-module/mutations.js
+++ b/src/service-module/mutations.js
@@ -1,5 +1,5 @@
 import _merge from 'lodash.merge'
-import _cloneDeep from 'lodash.clonedeep'
+import deepCopy from 'fast-copy'
 import serializeError from 'serialize-error'
 import isObject from 'lodash.isobject'
 import { checkId } from '../utils'
@@ -172,7 +172,7 @@ export default function makeServiceMutations (servicePath, { debug, globalModels
         item = state.keyedById[id]
       }
       state.currentId = id
-      state.copy = _cloneDeep(item)
+      state.copy = deepCopy(item)
     },
 
     clearCurrent (state) {
@@ -230,7 +230,7 @@ export default function makeServiceMutations (servicePath, { debug, globalModels
         copy = Model.copiesById[id]
       }
 
-      _merge(current, copy)
+      Object.assign(current, copy)
     },
 
     // Stores pagination data on state.pagination based on the query identifier (qid)

--- a/src/service-module/service-module.js
+++ b/src/service-module/service-module.js
@@ -123,6 +123,8 @@ export default function servicePluginInit (feathersClient, globalOptions = {}, g
         _commit: {
           value (id) {
             store.commit(`${namespace}/commitCopy`, id)
+
+            return this._clone(id)
           }
         },
         _reset: {

--- a/test/service-module/service-module.test.js
+++ b/test/service-module/service-module.test.js
@@ -34,11 +34,16 @@ describe('Service Module', () => {
       })
       assert(store)
       assert(globalModels.hasOwnProperty('Todo'), 'the Model was added to the globalModels')
-
+      const owners = this.owners = [
+        { id: 1, name: 'Marshall' },
+        { id: 2, name: 'Mariah' },
+        { id: 3, name: 'Leah' }
+      ]
       const data = {
         id: 1,
         description: 'Do the dishes',
-        isComplete: false
+        isComplete: false,
+        owners
       }
       store.commit('todos/addItem', data)
 
@@ -70,6 +75,42 @@ describe('Service Module', () => {
       todoClone.commit()
 
       assert(todo.description === 'Do something else', 'the original todo was updated')
+    })
+
+    it('performs a shallow merge when commiting back to the original record', function () {
+      const { todo, todoClone, owners } = this
+
+      todoClone.owners = [
+        { id: 1, name: 'Marshall' },
+        { id: 2, name: 'Mariah' }
+      ]
+      assert.deepEqual(todo.owners, owners, 'original todo remained unchanged')
+
+      todoClone.commit()
+
+      assert.deepEqual(todo.owners, [ owners[0], owners[1] ], 'ownerIds were updated properly')
+    })
+
+    it(`changes the original record if you don't use the return value of commit()`, function () {
+      const { todo, todoClone, owners } = this
+
+      assert.deepEqual(todo.owners, owners, 'original todo remained unchanged')
+
+      todoClone.commit()
+      todoClone.owners[0].name = 'Ted'
+
+      assert.deepEqual(todo.owners[0].name, 'Ted', 'nested object in original todo was changed')
+    })
+
+    it(`doesn't change the original record if you use modify return value of a commit`, function () {
+      let { todo, todoClone, owners } = this
+
+      assert.deepEqual(todo.owners, owners, 'original todo remained unchanged')
+
+      todoClone = todoClone.commit()
+      todoClone.owners[0].name = 'Ted'
+
+      assert.deepEqual(todo.owners[0].name, 'Marshall', 'nested object in original todo was changed')
     })
 
     it('allows reseting copy changes back to match the original', function () {

--- a/test/service-module/service-module.test.js
+++ b/test/service-module/service-module.test.js
@@ -110,7 +110,7 @@ describe('Service Module', () => {
       todoClone = todoClone.commit()
       todoClone.owners[0].name = 'Ted'
 
-      assert.deepEqual(todo.owners[0].name, 'Marshall', 'nested object in original todo was changed')
+      assert.deepEqual(todo.owners[0].name, 'Marshall', 'nested object in original todo was NOT changed')
     })
 
     it('allows reseting copy changes back to match the original', function () {


### PR DESCRIPTION
Fixes https://github.com/feathers-plus/feathers-vuex/issues/116

```js
it('performs a shallow merge when commiting back to the original record', function () {
  const { todo, todoClone, owners } = this

  todoClone.owners = [
    { id: 1, name: 'Marshall' },
    { id: 2, name: 'Mariah' }
  ]
  assert.deepEqual(todo.owners, owners, 'original todo remained unchanged')

  todoClone.commit()

  assert.deepEqual(todo.owners, [ owners[0], owners[1] ], 'ownerIds were updated properly')
})

it(`changes the original record if you don't use the return value of commit()`, function () {
  const { todo, todoClone, owners } = this

  assert.deepEqual(todo.owners, owners, 'original todo remained unchanged')

  todoClone.commit()
  todoClone.owners[0].name = 'Ted'

  assert.deepEqual(todo.owners[0].name, 'Ted', 'nested object in original todo was changed')
})

it(`doesn't change the original record if you use modify return value of a commit`, function () {
  let { todo, todoClone, owners } = this

  assert.deepEqual(todo.owners, owners, 'original todo remained unchanged')

  todoClone = todoClone.commit()
  todoClone.owners[0].name = 'Ted'

  assert.deepEqual(todo.owners[0].name, 'Marshall', 'nested object in original todo was NOT changed')
})
```