### PR TITLE
Update pagination to use Vue.set to ensure it is reactive

### DIFF
--- a/src/service-module/mutations.js
+++ b/src/service-module/mutations.js
@@ -1,3 +1,4 @@
+import Vue from 'vue'
 import _merge from 'lodash.merge'
 import deepCopy from 'fast-copy'
 import serializeError from 'serialize-error'
@@ -241,7 +242,7 @@ export default function makeServiceMutations (servicePath, { debug, globalModels
       const ids = data.map(item => {
         return item[idField]
       })
-      state.pagination = { ...state.pagination, [qid]: { limit, skip, total, ids, query } }
+      Vue.set(state, 'pagination', { ...state.pagination, [qid]: { limit, skip, total, ids, query } })
     },
 
     setFindPending (state) {


### PR DESCRIPTION
### Summary
In ref to https://github.com/feathers-plus/feathers-vuex/issues/125

This is set to use `Vue.set` to update the pagination object so that it is kept reactive to updates.