### PR TITLE
Bug fix: Prevent sharing & changing of deep instanceDefaults

### DIFF
--- a/src/service-module/model.js
+++ b/src/service-module/model.js
@@ -1,3 +1,5 @@
+import fastCopy from 'fast-copy'
+
 const defaults = {
   idField: 'id',
   preferUpdate: false,
@@ -8,12 +10,12 @@ export default function (options) {
   options = Object.assign({}, defaults, options)
   const { idField, preferUpdate, instanceDefaults, globalModels, modelName } = options
   // Don't modify the original instanceDefaults. Clone it with accessors intact
-  let _instanceDefaults = cloneWithAccessors(instanceDefaults)
 
   class FeathersVuexModel {
     constructor (data = {}, options = {}) {
       const { store, namespace } = this.constructor
       const relationships = {}
+      const _instanceDefaults = cloneWithAccessors(instanceDefaults)
 
       Object.keys(_instanceDefaults).forEach(key => {
         const modelName = instanceDefaults[key]
@@ -187,12 +189,16 @@ function createRelatedInstance ({ item, Model, idField, store }) {
 }
 
 function cloneWithAccessors (obj) {
-  var clone = Object.create(Object.getPrototypeOf(obj))
+  const clone = fastCopy(obj)
 
   var props = Object.getOwnPropertyNames(obj)
   props.forEach(key => {
     var desc = Object.getOwnPropertyDescriptor(obj, key)
-    Object.defineProperty(clone, key, desc)
+
+    // Copy over accessors
+    if (desc.get || desc.set) {
+      Object.defineProperty(clone, key, desc)
+    }
   })
 
   return clone

--- a/test/service-module/service-module.test.js
+++ b/test/service-module/service-module.test.js
@@ -138,6 +138,9 @@ describe('Service Module', () => {
             instanceDefaults: {
               firstName: '',
               lastName: '',
+              location: {
+                coordinates: [ -111.549668, 39.014 ]
+              },
               get fullName () {
                 return `${this.firstName} ${this.lastName}`
               }
@@ -193,6 +196,16 @@ describe('Service Module', () => {
       })
 
       assert.equal(person.fullName, `Marshall Thompson`, 'the es5 getter returned the correct value')
+    })
+
+    it('does not allow sharing of deeply nested objects between instances', function () {
+      const { Person } = this
+      const person1 = new Person({ firstName: 'Marshall', lastName: 'Thompson' })
+      const person2 = new Person({ firstName: 'Austin', lastName: 'Thompson' })
+
+      person1.location.coordinates[0] = 5
+
+      assert.equal(person2.location.coordinates[0], -111.549668, 'the value was not shared')
     })
 
     it('keeps the options on the Model', function () {


### PR DESCRIPTION
Deeply nested objects in `instanceDefaults` were not accounted for, so it was possible for the values to be shared between objects when two instances were using the defaults.  This sharing has been fixed by using `fast-copy` to get a deep clone of the `instanceDefaults` before copying over the accessors (es5 getters & setters).

```js
service('people', {
  instanceDefaults: {
    location: {
      coordinates: [ -111.549668, 39.014 ]
    }
  }
})

it('does not allow sharing of deeply nested objects between instances', function () {
  const { Person } = this
  const person1 = new Person()
  const person2 = new Person()

  person1.location.coordinates[0] = 5

  assert.equal(person2.location.coordinates[0], -111.549668, 'the value was not shared')
})
```