### PR TITLE
Fix setCurrent mutation and copy accessors

### DIFF
--- a/src/service-module/mutations.js
+++ b/src/service-module/mutations.js
@@ -1,6 +1,5 @@
 import Vue from 'vue'
 import _merge from 'lodash.merge'
-import deepCopy from 'fast-copy'
 import serializeError from 'serialize-error'
 import isObject from 'lodash.isobject'
 import { checkId } from '../utils'
@@ -10,8 +9,8 @@ export default function makeServiceMutations (servicePath, { debug, globalModels
 
   function addItem (state, item) {
     const { idField } = state
-    const Model = globalModels.byServicePath[servicePath]
     let id = item[idField]
+    const Model = globalModels.byServicePath[servicePath]
     const isIdOk = checkId(id, item, debug)
 
     if (isIdOk) {
@@ -163,8 +162,10 @@ export default function makeServiceMutations (servicePath, { debug, globalModels
 
     setCurrent (state, itemOrId) {
       const { idField } = state
+      const Model = globalModels.byServicePath[servicePath]
       let id
       let item
+
       if (isObject(itemOrId)) {
         id = itemOrId[idField]
         item = itemOrId
@@ -173,7 +174,8 @@ export default function makeServiceMutations (servicePath, { debug, globalModels
         item = state.keyedById[id]
       }
       state.currentId = id
-      state.copy = deepCopy(item)
+
+      state.copy = new Model(item, { isClone: true })
     },
 
     clearCurrent (state) {

--- a/test/service-module/service-module.test.js
+++ b/test/service-module/service-module.test.js
@@ -166,6 +166,18 @@ describe('Service Module', () => {
       assert.deepEqual(todo, {}, 'default model is an empty object')
     })
 
+    it('setCurrent works on model instances with getters', function () {
+      const { Person, store } = this
+      const person = new Person({
+        id: 1,
+        firstName: 'Al',
+        lastName: 'fred'
+      })
+      store.commit('people/setCurrent', person)
+
+      assert(store.state.people.copy.fullName === 'Al fred', 'setCurrent preserved the getter accessor prop')
+    })
+
     it('stores clones in Model.copiesById by default', function () {
       const { Todo } = this
       const todo = new Todo({ id: 1, description: 'Do something' })


### PR DESCRIPTION
This adds backwards compatibility with the `setCurrent` mutation and instance-level getters/setters.  The `setCurrent` mutation would break because the `fast-copy` module causes an error to be thrown when trying to copy an object with an accessor attribute that only has a getter (no setter).  This adds tests for a fix for that scenario.