### PR TITLE
Rollup compatibility

### DIFF
--- a/src/service-module/getters.js
+++ b/src/service-module/getters.js
@@ -27,7 +27,7 @@ export default function makeServiceGetters (servicePath) {
       }
 
       if (filters.$select) {
-        values = values.map(value => _.pick(value, ...filters.$select))
+        values = values.map(value => _.pick(value, filters.$select.slice()))
       }
 
       return {

--- a/src/service-module/mutations.js
+++ b/src/service-module/mutations.js
@@ -23,10 +23,7 @@ export default function makeServiceMutations (servicePath, { debug, globalModels
         state.ids.push(id)
       }
 
-      state.keyedById = {
-        ...state.keyedById,
-        [id]: item
-      }
+      Vue.set(state.keyedById, id, item)
     }
   }
 
@@ -48,10 +45,7 @@ export default function makeServiceMutations (servicePath, { debug, globalModels
     // if addOnUpsert then add the record into the state, else discard it.
     if (addOnUpsert) {
       state.ids.push(id)
-      state.keyedById = {
-        ...state.keyedById,
-        [id]: item
-      }
+      Vue.set(state.keyedById, id, item)
     }
   }
 
@@ -244,7 +238,7 @@ export default function makeServiceMutations (servicePath, { debug, globalModels
       const ids = data.map(item => {
         return item[idField]
       })
-      Vue.set(state, 'pagination', { ...state.pagination, [qid]: { limit, skip, total, ids, query } })
+      Vue.set(state.pagination, qid, { limit, skip, total, ids, query })
     },
 
     setFindPending (state) {

--- a/src/service-module/state.js
+++ b/src/service-module/state.js
@@ -1,5 +1,5 @@
 export default function makeDefaultState (servicePath, options) {
-  const { idField, autoRemove, paginate, enableEvents, addOnUpsert, skipRequestIfExists, preferUpdate, replaceItems } = options
+  const { idField, autoRemove, enableEvents, addOnUpsert, skipRequestIfExists, preferUpdate, replaceItems } = options
   const state = {
     ids: [],
     keyedById: {},
@@ -14,6 +14,7 @@ export default function makeDefaultState (servicePath, options) {
     skipRequestIfExists,
     preferUpdate,
     replaceItems,
+    pagination: {},
 
     isFindPending: false,
     isGetPending: false,
@@ -29,8 +30,6 @@ export default function makeDefaultState (servicePath, options) {
     errorOnPatch: null,
     errorOnRemove: null
   }
-  if (paginate) {
-    state.pagination = {}
-  }
+
   return state
 }

--- a/test/service-module/service-module.test.js
+++ b/test/service-module/service-module.test.js
@@ -727,7 +727,8 @@ describe('Service Module', () => {
         skipRequestIfExists: false,
         preferUpdate: false,
         replaceItems: false,
-        servicePath: 'todos'
+        servicePath: 'todos',
+        pagination: {}
       }
 
       assert.deepEqual(todoState, expectedState, 'the expected state was returned')


### PR DESCRIPTION
This PR removes the use of `...` rest/spread operators for simpler rollup compatibility.  It also simplifies the state.pagination to always initialize with an empty object, even if pagination is turned off.