### PR TITLE
Fix slowness when finding a large number of items

### DIFF
--- a/src/service-module/actions.js
+++ b/src/service-module/actions.js
@@ -256,7 +256,7 @@ export default function makeServiceActions (service, { debug }) {
 
       if (service.Model) {
         toAdd.forEach((item, index) => {
-          toAdd[index] = new service.Model(item)
+          toAdd[index] = new service.Model(item, {skipCommit: true})
         })
       }
 

--- a/src/service-module/model.js
+++ b/src/service-module/model.js
@@ -92,7 +92,7 @@ export default function (options) {
       })
 
       // If this record has an id, addOrUpdate the store
-      if (data[idField] && !options.isClone) {
+      if (data[idField] && !options.isClone && !options.skipCommit) {
         store.dispatch(`${namespace}/addOrUpdate`, this)
       }
     }


### PR DESCRIPTION
addOrUpdateList was duplicating work, and the keyedById object
was being cloned, handed to Vue to be made reactive before being thrown away,
over and over again through the loop. Instead, now do as much work as possible
by batching addItem mutations together.
