### PR TITLE
fix 174

### DIFF
--- a/src/auth-module/auth-module.js
+++ b/src/auth-module/auth-module.js
@@ -2,6 +2,7 @@ import setupState from './state'
 import setupGetters from './getters'
 import setupMutations from './mutations'
 import setupActions from './actions'
+import { sharedContext } from '../utils'
 
 const defaults = {
   namespace: 'auth',
@@ -28,13 +29,14 @@ export default function authPluginInit (feathersClient, globalOptions = {}, glob
     const defaultGetters = setupGetters()
     const defaultMutations = setupMutations(feathersClient)
     const defaultActions = setupActions(feathersClient, globalModels)
+    const state = sharedContext.authState = Object.assign({}, defaultState, options.state)
 
     return function setupStore (store) {
       const { namespace } = options
 
       store.registerModule(namespace, {
         namespaced: true,
-        state: Object.assign({}, defaultState, options.state),
+        state,
         getters: Object.assign({}, defaultGetters, options.getters),
         mutations: Object.assign({}, defaultMutations, options.mutations),
         actions: Object.assign({}, defaultActions, options.actions)

--- a/src/service-module/actions.js
+++ b/src/service-module/actions.js
@@ -92,8 +92,7 @@ export default function makeServiceActions (service, { debug }) {
       const existedItem = getters.get(id, params)
       if (existedItem) {
         commit('setCurrent', existedItem)
-        if (!skipRequestIfExists) getFromRemote()
-        return Promise.resolve(existedItem)
+        if (skipRequestIfExists) return Promise.resolve(existedItem)
       }
       return getFromRemote()
     },

--- a/src/service-module/state.js
+++ b/src/service-module/state.js
@@ -1,5 +1,5 @@
 export default function makeDefaultState (servicePath, options) {
-  const { idField, autoRemove, enableEvents, addOnUpsert, diffOnPatch, skipRequestIfExists, preferUpdate, replaceItems } = options
+  const { idField, autoRemove, enableEvents, addOnUpsert, diffOnPatch, skipRequestIfExists, preferUpdate, replaceItems, customMerge } = options
   const state = {
     ids: [],
     keyedById: {},
@@ -15,6 +15,7 @@ export default function makeDefaultState (servicePath, options) {
     skipRequestIfExists,
     preferUpdate,
     replaceItems,
+    customMerge,
     pagination: {},
 
     isFindPending: false,

--- a/src/utils.js
+++ b/src/utils.js
@@ -173,3 +173,5 @@ export function setByDot (obj, path, value, ifDelete) {
 export function diffFunctions () {
   return diff
 }
+
+export const sharedContext = {}

--- a/test/service-module/actions.test.js
+++ b/test/service-module/actions.test.js
@@ -329,10 +329,10 @@ describe('Service Module - Actions', () => {
               actions.get.call({$store: store}, [0, {}])
                 .then(response3 => {
                   expectedKeyedById = {
-                    0: { id: 0, description: 'Do the FIRST' },
+                    0: { id: 0, description: 'Do the first' },
                     1: { id: 1, description: 'Do the second' }
                   }
-                  assert(response3.description === 'Do the FIRST')
+                  assert(response3.description === 'Do the first')
                   assert.deepEqual(todoState.keyedById, expectedKeyedById)
 
                   // Wait for the remote data to arriive

--- a/test/service-module/service-module.test.js
+++ b/test/service-module/service-module.test.js
@@ -729,6 +729,7 @@ describe('Service Module', () => {
         skipRequestIfExists: false,
         preferUpdate: false,
         replaceItems: false,
+        customMerge: undefined,
         servicePath: 'todos',
         pagination: {}
       }


### PR DESCRIPTION
# fix #174 
- added sharedContext to util, so things can be shared internally between modules
- fixed replaceItem not updating the auth.user
- added customMerge option to updateItems, so userland can implement custom merging solutions for their app
- fixed get Action for service module returning existing regardless
- updated testing to reflect changes

Please review my comment in #174 regarding the get Action fix, and whether it should be reverted before approving

Edit: This should also provide a fix for #143 and #166 