### PR TITLE
Use merge for toJson object

### DIFF
--- a/src/service-module/model.js
+++ b/src/service-module/model.js
@@ -1,4 +1,5 @@
 import fastCopy from 'fast-copy'
+import _merge from 'lodash.merge'
 
 const defaults = {
   idField: 'id',
@@ -170,7 +171,7 @@ export default function (options) {
     _remove () {}
 
     toJSON () {
-      return fastCopy(this)
+      return _merge({}, this)
     }
   }
 


### PR DESCRIPTION
This will avoid infinite recursion with circular references

### Summary
- [x] Tell us about the problem your pull request is solving.
#196 - infinite recursion when there are circular references
- [x] Are there any open issues that are related to this?
closes #196, caused by #179 
- [x] Is this PR dependent on PRs in other repos?
caused by #179 

### Other Information

#### Question
- Is merge the best route here? it's probably the easiest, but maybe not the most performant  if we already know the key we want to copy to the json object.
- Should we use merge for `cloneWithAccessors`?