### PR TITLE
Fix link to full documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 [Demo](https://codesandbox.io/s/xk52mqm7o)
 
-See [https://feathers-vuex.feathers-plus./index.html](https://feathers-vuex.feathers-plus.com./index.html) for full documentation.
+See [https://feathers-vuex.feathers-plus.com/index.html](https://feathers-vuex.feathers-plus.com/index.html) for full documentation.
 
 ## Installation
 


### PR DESCRIPTION
### Summary

This just fixes the link & label to the full documentation pages in the README.