### PR TITLE
Fixed method name in code example

### DIFF
--- a/docs/model-classes.md
+++ b/docs/model-classes.md
@@ -58,7 +58,7 @@ Model classes have a `getFromStore` method, which is a proxy to the [`get` gette
 // In your Vue component
 created () {
   const { Todo } = this.$FeathersVuex
-  const todo = Todo.findInStore(this.id)
+  const todo = Todo.getFromStore(this.id)
 }
 ```
 


### PR DESCRIPTION
Changed `findInStore` to `getFromStore` in code sample
