### PR TITLE
Adding dynamically generated QID in the MakeFindMixin

### DIFF
--- a/docs/mixins.md
+++ b/docs/mixins.md
@@ -76,7 +76,7 @@ The `makeFindMixin` and `makeGetMixin` utilities share the following options in 
 
 The `makeFindMixin` has these unique options:
 
-- **qid {String}** - The "query identifier" ("qid", for short) is used for storing pagination data in the Vuex store. See the service module docs to see what you'll find inside.  The `qid` and its accompanying pagination data from the store will eventually be used for cacheing and preventing duplicate queries to the API.
+- **qid {String|Function}** - The "query identifier" ("qid", for short) is used for storing pagination data in the Vuex store. See the service module docs to see what you'll find inside.  The `qid` and its accompanying pagination data from the store will eventually be used for cacheing and preventing duplicate queries to the API.
 
 ### Options for only `makeGetMixin`
 
@@ -216,5 +216,27 @@ const mixedInDataFromAboveExample = {
     // The mixin will expect to find this. This won't be created automatically.
     serviceQuery () {}
   }
+}
+```
+
+## Using a dynamic qid
+
+It's also possible to set your qid dynamically. For example, if yout want to query for the coments of a post:
+
+```js
+export default {
+  props: {
+    postId: {
+      type: String,
+      required: true
+    }
+  },
+  mixins: [
+    makeFindMixin({
+      service: 'posts',
+      name: 'postComments',
+      qid () { return `${this.postId}_coments` }
+    })
+  ]
 }
 ```

--- a/src/make-find-mixin.js
+++ b/src/make-find-mixin.js
@@ -16,9 +16,6 @@ export default function makeFindMixin (options) {
   if (typeof service === 'function' && !name) {
     name = 'service'
   }
-  if (typeof qid === 'function') {
-    qid = qid()
-  }
 
   const nameToUse = (name || service).replace('-', '_')
   const prefix = getServicePrefix(nameToUse)
@@ -40,8 +37,7 @@ export default function makeFindMixin (options) {
   const QID = `${prefix}Qid`
   const data = {
     [IS_FIND_PENDING]: false,
-    [WATCH]: watch,
-    [QID]: qid
+    [WATCH]: watch
   }
 
   const mixin = {
@@ -79,7 +75,7 @@ export default function makeFindMixin (options) {
               paramsToUse.query = paramsToUse.query || {}
 
               if (qid) {
-                paramsToUse.qid = qid
+                paramsToUse.qid = this[QID]
               }
 
               return this.$store.dispatch(`${this[SERVICE_NAME]}/find`, paramsToUse)
@@ -127,11 +123,12 @@ export default function makeFindMixin (options) {
 
   if (qid) {
     mixin.computed[PAGINATION] = function () {
-      return this.$store.state[this[SERVICE_NAME]].pagination[qid]
+      return this.$store.state[this[SERVICE_NAME]].pagination[this[QID]]
     }
   }
 
   setupAttribute(SERVICE_NAME, service, 'computed', true)
+  setupAttribute(QID, qid, 'computed', true)
   setupAttribute(PARAMS, params)
   setupAttribute(FETCH_PARAMS, fetchQuery)
   setupAttribute(QUERY_WHEN, queryWhen, 'methods')

--- a/src/make-find-mixin.js
+++ b/src/make-find-mixin.js
@@ -1,8 +1,8 @@
 import { getServicePrefix, getServiceCapitalization } from './utils'
 
 export default function makeFindMixin (options) {
-  const { service, params, fetchQuery, queryWhen = () => true, local = false, qid = 'default', items, debug } = options
-  let { name, watch = [] } = options
+  const { service, params, fetchQuery, queryWhen = () => true, local = false, items, debug } = options
+  let { name, qid = 'default', watch = [] } = options
 
   if (typeof watch === 'string') {
     watch = [watch]
@@ -15,6 +15,9 @@ export default function makeFindMixin (options) {
   }
   if (typeof service === 'function' && !name) {
     name = 'service'
+  }
+  if (typeof qid === 'function') {
+    qid = qid()
   }
 
   const nameToUse = (name || service).replace('-', '_')


### PR DESCRIPTION
I've been strugling to get the pagination to work correctly and one of the problems was that I couldn't create dinamical qid's, so I would have the comments of a post show a total of the pagination of a different post that was visited before as they would share the same qid.

This is a simple implementation and maybe there is something already been done for the next version, but anyway.