### PR TITLE
addItems mutation fix tempId

### DIFF
--- a/src/service-module/service-module.mutations.ts
+++ b/src/service-module/service-module.mutations.ts
@@ -41,7 +41,7 @@ export default function makeServiceMutations() {
 
       if (isTemp) {
         let tempId = item[tempIdField];
-        if (!tempId) {
+        if (tempId == null) {
           tempId = assignTempId(state, item)
         }
         item.__isTemp = true

--- a/src/service-module/service-module.mutations.ts
+++ b/src/service-module/service-module.mutations.ts
@@ -40,8 +40,9 @@ export default function makeServiceMutations() {
       }
 
       if (isTemp) {
-        if (!item[tempIdField]) {
-          var tempId = assignTempId(state, item)
+        let tempId = item[tempIdField];
+        if (!tempId) {
+          tempId = assignTempId(state, item)
         }
         item.__isTemp = true
         newTempsById[tempId] = item


### PR DESCRIPTION
Currently I'm programming an progressive web app with feathers-vuex and localForage. I stumbled upon this. I wanted to restore `keyedById` from IndexedDB by using `addItems`. Instead of just overwriting the stores `keyedById` by the IndexedDB ones, I wanted to have them as Vuex-Models :)

This little change should fix the problem. Everything works for me now.

If `tempId` was assigned before calling `addItems`-mutation -> `tempId` is undefined -> `newTempsById[undefined] = item`

Again thanks for this great module! <3