### PR TITLE
Fix model find

### DIFF
--- a/src/service-module/make-model.ts
+++ b/src/service-module/make-model.ts
@@ -164,7 +164,7 @@ export default function makeModel(options: FeathersVuexOptions) {
     }
 
     public static find(params) {
-      this._dispatch('find', params)
+      return this._dispatch('find', params)
     }
 
     public static findInStore(params) {

--- a/test/service-module/model-methods.test.ts
+++ b/test/service-module/model-methods.test.ts
@@ -134,10 +134,17 @@ describe('Models - Methods', function () {
     clearModels()
   })
 
-  it('Model.find', function () {
+  it('Model.find is a function', function () {
     const { Task } = makeContext()
 
     assert(typeof Task.find === 'function')
+  })
+
+  it('Model.find returns a Promise', function () {
+    const { Task } = makeContext()
+    const result = Task.find()
+    assert(typeof result.then !== 'undefined')
+    result.catch(err => { /* noop -- prevents UnhandledPromiseRejectionWarning */})
   })
 
   it('Model.findInStore', function () {


### PR DESCRIPTION
### Summary

Assuming [the Model API described in the current docs](https://feathers-vuex.feathers-plus.com/model-classes.html#model-methods) is not intended to change, I think you accidentally forgot to prefix [this line](https://github.com/feathers-plus/feathers-vuex/blob/v2.0.0-pre.77/src/service-module/make-model.ts#L167) with `return`.

It's resulting in, e.g.

```js
const { User } = this.$FeathersVuex.myApi
User.find().then(users => { /* ... do something with users ... */})
```

thowing the error:

`TypeError: Cannot read property 'then' of undefined`

The [current test](https://github.com/feathers-plus/feathers-vuex/blob/v2.0.0-pre.77/test/service-module/model-methods.test.ts#L137) only checks whether or not `Model.find()` is a function, and not whether or not it returns the correct type. I added a test to check the return type, as well.

### Expected behavior

`Model.find()` should return a Promise.

### Actual behavior

`Model.find()` returns nothing.

### Other Information

This is intended to be part of the 2.0 (TypeScript branch) release. (This is such a tiny PR, I won't be offended in the slightest if you decide it's easier to fix it in your own branch rather than merging this one. 😉)
