### PR TITLE
fix "Cannot read property '_' of undefined" in v1

### DIFF
--- a/src/service-module/getters.js
+++ b/src/service-module/getters.js
@@ -1,9 +1,8 @@
 import sift from 'sift'
-import commons from '@feathersjs/commons'
+import { _ } from '@feathersjs/commons'
 import dbCommons from '@feathersjs/adapter-commons'
 import omit from 'lodash.omit'
 
-const { _ } = commons
 const { filterQuery, sorter, select } = dbCommons
 const FILTERS = [ '$sort', '$limit', '$skip', '$select' ]
 const OPERATORS = [ '$in', '$nin', '$lt', '$lte', '$gt', '$gte', '$ne', '$or' ]


### PR DESCRIPTION
### Summary

- [x] Tell us about the problem your pull request is solving: Fix "Cannot read property '_' of undefined" in v1 in `src/service-module/getters.js`
- [x] Are there any open issues that are related to this? https://github.com/feathers-plus/feathers-vuex/issues/247
- [x] Is this PR dependent on PRs in other repos? No


### Other Information

I have the same error as in https://github.com/feathers-plus/feathers-vuex/issues/247 and I can't upgrade to v2. The solution was to make a PR with this simple change (https://github.com/feathers-plus/feathers-vuex/issues/247#issuecomment-530085760), but as nobody did it, here is the PR.

Thank you in advance for accepting it.