### PR TITLE
vite 2.7.0 warning fix by using conditional exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "description": "FeathersJS, Vue, and Nuxt for the artisan developer",
   "version": "3.16.0",
   "homepage": "https:feathers-vuex.feathersjs-ecosystem.com",
-  "main": "dist/",
-  "module": "dist/",
+  "main": "dist/index.js",
   "types": "dist/",
+  "exports": {
+    "import": "dist/index.js"
+  },
   "keywords": [
     "vue",
     "feathers",


### PR DESCRIPTION
# Summary
Vite 2.7.0 users are getting `@feathersjs/vuex is incorrectly packaged. Please contact the package author to fix.`  
https://github.com/vitejs/vite/discussions/6013   
![Screenshot from 2021-12-08 15-08-53](https://user-images.githubusercontent.com/876076/145337085-4c387a03-b2a1-4921-9862-4f6ee1f6a3bb.png)

This provides a fix by declaring that we export ESM. The main is still technically incorrect, but that's harder to fix as we use Typescript and they haven't released Node Native ESM support as of TS 4.5.  
The same fix works on [4.0.1-pre.7](https://unpkg.com/browse/@feathersjs/vuex@4.0.1-pre.7/dist/), which someone forgot to tag in GH

# Sandbox
https://stackblitz.com/edit/feathersjs-wy4w68?file=vuex-package.json

# Risks
- Declaring exports makes Node block access to undeclared entry points
- I've only tested this on one environment... I'd let it simmer for a week. Unless you're pushing to the alpha... in which case...

# Alternative solutions
- change the extension of the main script to `.mjs`
- Change the package.json/type to "module" (could break tests, debugging, typescript linting etc)

# Sources
https://nodejs.org/api/packages.html#conditional-exports

